### PR TITLE
update CHANGELOG.md & .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: node_js
+
 node_js:
-  - "0.11"
-  - "0.10"
-  - "0.8"
-  - "0.6"
+  - '0.12'
+  - '0.10'
+sudo: false # Enable docker-based containers
+cache:
+  directories: # Cache dependencies
+    - node_modules
+
+script:
+  - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,112 +2,135 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.0.19](https://github.com/Esri/koop/releases/tag/v1.0.19) - 2015-03-04
-###Changed
-- We are now using the latest node-mapnik versions which should help with installs on Windows
+## [1.0.19] - 2015-03-04
+### Changed
+* We are now using the latest [node-mapnik](https://github.com/mapnik/node-mapnik) version, which should help with installs on Windows.
 
-## [1.0.18](https://github.com/Esri/koop/releases/tag/v1.0.18) - 2015-03-02
-###Added
-- support for koop-pgcache to export workers
+## [1.0.18] - 2015-03-02
+### Added
+- support for `koop-pgcache` to export workers
 
-## [1.0.17](https://github.com/Esri/koop/releases/tag/v1.0.17) - 2015-03-02
-###Changed
-- Koop longer ships with default support for PostGIS or Spatiallite. These have become optional plugins
-  - this means that need to be added the koop module at server start up time
-  - koop now ships with a Local cache out of the box that is not persisted across server sessions
+## [1.0.17] - 2015-03-02
+### Changed
+- Koop no longer ships with default support for PostGIS or SpatiaLite. These have become optional plugins.
+  - this means they need to be added the koop module at server start up time
+  - koop now ships with a `Local` cache out of the box that is not persisted across server sessions
 
+## [1.0.16] - 2015-02-13
+### Fixed
+- Added missing `connect-multiparty` module to `package.json`
 
-## [1.0.16](https://github.com/Esri/koop/releases/tag/v1.0.16) - 2015-02-13
-###Changed
-- Fized the package json missing the multipart post module
+## [1.0.15] - 2015-02-12
+### Added
+- Added support for multipart form posts
 
-## [1.0.15](https://github.com/Esri/koop/releases/tag/v1.0.15) - 2015-02-12
-###Added
-- added a the module connect-multipart to support multipart form posts
+### Changed
+- Fixed the way feature service requests handle query strings to the info endpoints
 
-###Changes
-- fixed the way feature service requests handle query strings to the info endpoints
-
-
-## [1.0.14](https://github.com/Esri/koop/releases/tag/v1.0.14) - 2015-02-10
-###Changed
+## [1.0.14] - 2015-02-10
+### Changed
 - default routes needed to add support for POSTs to feature service endpoints
 - worker exporters needed to exit more gracefully and stop working when a file fails to be created
-- a typo in GeoJSON.fromEsri was crashing request pages in koop-agol
+- a typo in `GeoJSON.fromEsri` was crashing request pages in `koop-agol`
 
-
-## [1.0.13](https://github.com/Esri/koop/releases/tag/v1.0.13) - 2015-02-02
-###Changed
+## [1.0.13] - 2015-02-02
+### Changed
 - changed the way tiles are created, rather than creating a file on disk, now we just pass the mapnik XML around
-- using ST_Simplify instead of ST_SimplifyPreserveTopology for speed
+- using `ST_Simplify` instead of `ST_SimplifyPreserveTopology` for speed
 
-## [1.0.12](https://github.com/Esri/koop/releases/tag/v1.0.12) - 2015-01-29
+## [1.0.12] - 2015-01-29
 ### Added
-- now sending the expiration time with the base json response, helps with cache life
+- Now sending expiration time with base JSON response (helps with cache life)
 
 ### Changed
-- Tile styles are defaulted to points
+- Set default tile style to points
 
-## [1.0.11](https://github.com/Esri/koop/releases/tag/v1.0.11) - 2015-01-27
+## [1.0.11] - 2015-01-27
 ### Changed
-- fixed support for bad outStatistics params in the url
+- Fixed support for bad `outStatistics` params in the URL
 
-## [1.0.10](https://github.com/Esri/koop/releases/tag/v1.0.10) - 2015-01-26
+## [1.0.10] - 2015-01-26
 ### Changed
 - using mapnik-pool for all tiles now
 - refactored tiles for better vector tile buffer/edge support in the mapnik
 - PBF tiles are now deflated via zlib, which makes them smaller
-  - providers need to set the header
-    - `content-encoding: deflate`
+  - providers need to set the header `content-encoding: deflate`
 
-## [1.0.9](https://github.com/Esri/koop/releases/tag/v1.0.9) - 2015-01-21
+## [1.0.9] - 2015-01-21
 ### Changed
 - splitting objectIds for feature service queries
   - must be a string, not an array now (as per the geoservices rest spec)
 
-## [1.0.8](https://github.com/Esri/koop/releases/tag/v1.0.8) - 2015-01-21
+## [1.0.8] - 2015-01-21
 ### Changed
 - fixed an issue with object id fields in feature service queries for Ids with filters
   - when using returnIdsOnly the objectID was not getting set, which return false rows.
 
-## [1.0.7](https://github.com/Esri/koop/releases/tag/v1.0.7) - 2015-01-20
+## [1.0.7] - 2015-01-20
 ### Changed
 - lib/Tiles.js now passes along an optional name param to the tile generator. Vector tile use this name to store features.
 - fixed the tests, they are passing but jshint is not.
 - changed the way the lib/BaseController.js sends back its statuses.
 
-## [1.0.6](https://github.com/Esri/koop/releases/tag/v1.0.6) - 2015-01-16
+## [1.0.6] - 2015-01-16
 ### Added
 - a flag to the lib/Exporter.js class that will lock export jobs to prevent duplicate jobs stepping on each other in the queue.
   - This means that one job per dataset can be enqueued at a time.
   - Down the road this may cause problems for when we want to pre-cache several formats for the same dataset at the same time. That bridge will be crossed at that time.
 
-## [1.0.5](https://github.com/Esri/koop/releases/tag/v1.0.5) - 2015-01-15
+## [1.0.5] - 2015-01-15
 ### Added
 - a flag to the lib/PostGIS.js cache too ignore the selection limit unless a provider wants to use it.
   - since this feature is used by only a couple providers it seemed better to make it an opt-in option for the few, rather than an opt-out option across every provider.
 
-## [1.0.3](https://github.com/Esri/koop/releases/tag/v1.0.3) - 2015-01-13
+## [1.0.4] - 2015-01-15
+### Added
+- adding an ability to override koop's data limit of 2k.
+
+## [1.0.3] - 2015-01-13
 ### Changed
 - Fixed a bug in the ExportWorker where shps were being created as a directory with an extension .shp; this fixes some formatting errors that were related.
 
-## [1.0.2](https://github.com/Esri/koop/releases/tag/v1.0.2) - 2015-01-13
+## [1.0.2] - 2015-01-13
 ### Changed
 - Koop exports now force OGR to create shp file dirs instead of files; This adds more consistency so the code can maintain a single way for creating zip exports
 - The query support for outStatistics now removes any passed in slashes so it stops choking on parsing semi-bad inputs
 - The large data limit was moved from 10k features to 2k. This helps koop when its deployed with workers in that more work is handed down to the workers, which is good.
 
 
-## [1.0.1](https://github.com/Esri/koop/releases/tag/1.0.1) - 2015-01-08
+## [1.0.1] - 2015-01-08
 ### Added
-- for providers where hosts are used the info in the cache now stores the id of the host for that datasets
-- new providers endpoints for accessing metadata about installed providers and all data in the cache per provider
-- CSV files now get a BOM to help with parsing utf8 chars in Excel
+- For providers where hosts are used the info in the cache now stores the ID of the host for that datasets
+- New providers endpoints for accessing metadata about installed providers and all data in the cache per provider
+- CSV files now get a BOM to help with parsing utf-8 chars in Excel
 - Updated the docs in the readme to be a tad bit cleaner
 
-## [1.0.0](https://github.com/Esri/koop/releases/tag/1.0.0) - 2014-12-30
+## [1.0.0] - 2014-12-30
+Koop is now just a node module that exposes an express middleware app with hooks to register koop providers. This pattern represents a cleaner way to structure using koop with a series of other modules and makes deploying to places like Heroku and AWS much easier.
+
 ### Added
 - Version 1.0.0 changes many thing
   - koop is now a module, installable via `npm install`
   - koop-server is no more; all central code is in the koop project
   - to use Koop you must use it as middleware in an app that boots up an http server
+
+[1.0.19]: https://github.com/Esri/koop/compare/v1.0.18...v1.0.19
+[1.0.18]: https://github.com/Esri/koop/compare/v1.0.17...v1.0.18
+[1.0.17]: https://github.com/Esri/koop/compare/v1.0.16...v1.0.17
+[1.0.16]: https://github.com/Esri/koop/compare/v1.0.15...v1.0.16
+[1.0.15]: https://github.com/Esri/koop/compare/v1.0.14...v1.0.15
+[1.0.14]: https://github.com/Esri/koop/compare/v1.0.13...v1.0.14
+[1.0.13]: https://github.com/Esri/koop/compare/v1.0.12...v1.0.13
+[1.0.12]: https://github.com/Esri/koop/compare/v1.0.11...v1.0.12
+[1.0.11]: https://github.com/Esri/koop/compare/v1.0.10...v1.0.11
+[1.0.10]: https://github.com/Esri/koop/compare/v1.0.9...v1.0.10
+[1.0.9]: https://github.com/Esri/koop/compare/v1.0.8...v1.0.9
+[1.0.8]: https://github.com/Esri/koop/compare/v1.0.7...v1.0.8
+[1.0.7]: https://github.com/Esri/koop/compare/v1.0.6...v1.0.7
+[1.0.6]: https://github.com/Esri/koop/compare/v1.0.5...v1.0.6
+[1.0.5]: https://github.com/Esri/koop/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/Esri/koop/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/Esri/koop/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/Esri/koop/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/Esri/koop/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/Esri/koop/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.0.19](https://github.com/Esri/koop/releases/tag/v1.0.19) - 2015-03-04
 ###Changed
-- We are now using the latest node-mapnik versions which should help with installs on Windows 
+- We are now using the latest node-mapnik versions which should help with installs on Windows
 
 ## [1.0.18](https://github.com/Esri/koop/releases/tag/v1.0.18) - 2015-03-02
-###Added 
+###Added
 - support for koop-pgcache to export workers
 
 ## [1.0.17](https://github.com/Esri/koop/releases/tag/v1.0.17) - 2015-03-02
@@ -16,7 +19,7 @@
 
 ## [1.0.16](https://github.com/Esri/koop/releases/tag/v1.0.16) - 2015-02-13
 ###Changed
-- Fized the package json missing the multipart post module  
+- Fized the package json missing the multipart post module
 
 ## [1.0.15](https://github.com/Esri/koop/releases/tag/v1.0.15) - 2015-02-12
 ###Added
@@ -31,18 +34,18 @@
 - default routes needed to add support for POSTs to feature service endpoints
 - worker exporters needed to exit more gracefully and stop working when a file fails to be created
 - a typo in GeoJSON.fromEsri was crashing request pages in koop-agol
- 
+
 
 ## [1.0.13](https://github.com/Esri/koop/releases/tag/v1.0.13) - 2015-02-02
-###Changed 
-- changed the way tiles are created, rather than creating a file on disk, now we just pass the mapnik XML around 
-- using ST_Simplify instead of ST_SimplifyPreserveTopology for speed 
+###Changed
+- changed the way tiles are created, rather than creating a file on disk, now we just pass the mapnik XML around
+- using ST_Simplify instead of ST_SimplifyPreserveTopology for speed
 
 ## [1.0.12](https://github.com/Esri/koop/releases/tag/v1.0.12) - 2015-01-29
 ### Added
 - now sending the expiration time with the base json response, helps with cache life
 
-### Changed 
+### Changed
 - Tile styles are defaulted to points
 
 ## [1.0.11](https://github.com/Esri/koop/releases/tag/v1.0.11) - 2015-01-27
@@ -65,34 +68,34 @@
 ## [1.0.8](https://github.com/Esri/koop/releases/tag/v1.0.8) - 2015-01-21
 ### Changed
 - fixed an issue with object id fields in feature service queries for Ids with filters
-  - when using returnIdsOnly the objectID was not getting set, which return false rows. 
+  - when using returnIdsOnly the objectID was not getting set, which return false rows.
 
 ## [1.0.7](https://github.com/Esri/koop/releases/tag/v1.0.7) - 2015-01-20
-### Changed 
-- lib/Tiles.js now passes along an optional name param to the tile generator. Vector tile use this name to store features. 
-- fixed the tests, they are passing but jshint is not. 
-- changed the way the lib/BaseController.js sends back its statuses. 
+### Changed
+- lib/Tiles.js now passes along an optional name param to the tile generator. Vector tile use this name to store features.
+- fixed the tests, they are passing but jshint is not.
+- changed the way the lib/BaseController.js sends back its statuses.
 
 ## [1.0.6](https://github.com/Esri/koop/releases/tag/v1.0.6) - 2015-01-16
 ### Added
-- a flag to the lib/Exporter.js class that will lock export jobs to prevent duplicate jobs stepping on each other in the queue. 
-  - This means that one job per dataset can be enqueued at a time. 
-  - Down the road this may cause problems for when we want to pre-cache several formats for the same dataset at the same time. That bridge will be crossed at that time.  
+- a flag to the lib/Exporter.js class that will lock export jobs to prevent duplicate jobs stepping on each other in the queue.
+  - This means that one job per dataset can be enqueued at a time.
+  - Down the road this may cause problems for when we want to pre-cache several formats for the same dataset at the same time. That bridge will be crossed at that time.
 
 ## [1.0.5](https://github.com/Esri/koop/releases/tag/v1.0.5) - 2015-01-15
-### Added 
+### Added
 - a flag to the lib/PostGIS.js cache too ignore the selection limit unless a provider wants to use it.
-  - since this feature is used by only a couple providers it seemed better to make it an opt-in option for the few, rather than an opt-out option across every provider.  
+  - since this feature is used by only a couple providers it seemed better to make it an opt-in option for the few, rather than an opt-out option across every provider.
 
 ## [1.0.3](https://github.com/Esri/koop/releases/tag/v1.0.3) - 2015-01-13
 ### Changed
-- Fixed a bug in the ExportWorker where shps were being created as a directory with an extension .shp; this fixes some formatting errors that were related. 
+- Fixed a bug in the ExportWorker where shps were being created as a directory with an extension .shp; this fixes some formatting errors that were related.
 
 ## [1.0.2](https://github.com/Esri/koop/releases/tag/v1.0.2) - 2015-01-13
 ### Changed
 - Koop exports now force OGR to create shp file dirs instead of files; This adds more consistency so the code can maintain a single way for creating zip exports
 - The query support for outStatistics now removes any passed in slashes so it stops choking on parsing semi-bad inputs
-- The large data limit was moved from 10k features to 2k. This helps koop when its deployed with workers in that more work is handed down to the workers, which is good. 
+- The large data limit was moved from 10k features to 2k. This helps koop when its deployed with workers in that more work is handed down to the workers, which is good.
 
 
 ## [1.0.1](https://github.com/Esri/koop/releases/tag/1.0.1) - 2015-01-08
@@ -107,4 +110,4 @@
 - Version 1.0.0 changes many thing
   - koop is now a module, installable via `npm install`
   - koop-server is no more; all central code is in the koop project
-  - to use Koop you must use it as middleware in an app that boots up an http server 
+  - to use Koop you must use it as middleware in an app that boots up an http server

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Turn data into Feature Services.**
 
-Koop is a node.js module that exposes an [Express](http://expressjs.com/) server for the purpose of being used as middleware within an Express based application.  
+Koop is a node.js module that exposes an [Express](http://expressjs.com/) server for the purpose of being used as middleware within an Express based application.
 
 Koop provides a flexible server for exposing 3rd party data sources (APIs) as both [Feature Services](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Query_Feature_Service_Layer/02r3000000r1000000/) and other data formats (GeoJSON). This project is meant to provide a simple / pluggable platform for experimenting with various data within the ArcGIS platform. Koop aims to provide a platform for accessing any API and making it easy to consume within the realm of Esri's geospatial web products.
 
@@ -24,11 +24,10 @@ The following dependencies are needed in order to run Koop on your local machine
 
 ## Pre-Installation on Windows
 1. Setup the Python environmental variable
- 
+
   ```
   # Windows
   SET PYTHON = C:\Python27\python\python.exe
-  
   ```
 
 ## Installation
@@ -42,10 +41,10 @@ Basic installation would occur within an existing or new node.js project like so
 Then you would install a Koop Provider, like Github (see below for a full list of providers)
 
   ```
-  npm install koop-github 
+  npm install koop-github
   ```
 
-## Registering Providers 
+## Registering Providers
 
 Once you've installed koop and chosen a provider to work with you need to "register" the provider with koop
 
@@ -60,15 +59,15 @@ Once you've installed koop and chosen a provider to work with you need to "regis
       }
     }
   };
-  
-  // pass the config to koop 
+
+  // pass the config to koop
   var koop = require('koop')( config ),
   github = require('koop-github');
- 
+
   // register the provider with koop to bind its routes/handlers
   koop.register( github );
 
-  // create an express app 
+  // create an express app
   var express = require("express")
   var app = express();
 
@@ -78,8 +77,8 @@ Once you've installed koop and chosen a provider to work with you need to "regis
   // start the express server
   app.listen(process.env.PORT || config.server.port,  function() {
     console.log("Listening at http://%s:%d/", this.address().address, this.address().port);
-  }); 
-  ``` 
+  });
+  ```
 
 ## Data Providers
 
@@ -181,9 +180,8 @@ Not all capabilities of [Feature Services](http://resources.arcgis.com/en/help/a
 
 ## Resources
 
-* [ArcGIS Developers](http://developers.arcgis.com)
-* [ArcGIS REST Services](http://resources.arcgis.com/en/help/arcgis-rest-api/)
-* [twitter@esri](http://twitter.com/esri)
+* [ArcGIS REST API Documentation](http://resources.arcgis.com/en/help/arcgis-rest-api/)
+* [ArcGIS for Developers](http://developers.arcgis.com)
 
 ## Issues
 
@@ -191,7 +189,7 @@ Find a bug or want to request a new feature? Please let us know by submitting an
 
 ## Contributing
 
-Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](https://github.com/esri/contributing).
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](https://github.com/Esri/contributing).
 
 ## Licensing
 
@@ -209,7 +207,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](./license.txt) file.
 
 [](Esri Tags: ArcGIS Web Mapping GeoJson FeatureServices)
 [](Esri Language: JavaScript)

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-Apache License – 2.0
+Apache License - 2.0
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": {
     "name": "Chris Helm"
   },
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "dependencies": {
     "async": "~0.9.0",
     "aws-sdk": "~2.0.0",
@@ -39,7 +39,6 @@
     "type": "git",
     "url": "git://github.com/Esri/koop.git"
   },
-  "readmeFilename": "README.md",
   "bugs": {
     "url": "https://github.com/Esri/koop/issues"
   },


### PR DESCRIPTION
I updated the change log to reflect fixes to releases (#116) and added compare links to version titles (free version diffing, woo).

I also updated `.travis.yml` to target `0.10` and `0.12` only (since the docs say "Node.js (version > 0.10.0)" and 0.12 is the new stable release) as well as enabling caching and docker containers to speed up tests (#114).

I also fixed the link to the license in the readme and replaced an illegal character in `license.txt`.

> resolves #114 & #116