### PR TITLE
minor tweaks to package.json & readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+complexity

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # koop
 
-[![build status](https://api.travis-ci.org/Esri/koop.svg?branch=master)](https://travis-ci.org/Esri/koop)
+[![npm version](https://img.shields.io/npm/v/koop.svg?style=flat-square)](https://www.npmjs.com/package/koop)
+[![build status](https://img.shields.io/travis/Esri/koop.svg?style=flat-square)](https://travis-ci.org/Esri/koop)
 
 **Turn data into Feature Services.**
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test/models/ -t 20000",
-    "lint": "jshint lib/*"
+    "lint": "gulp"
   },
   "author": {
     "name": "Chris Helm"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A node module/express middleware for converting GeoJSON to Esri Feature Services.",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha test/models/ -t 20000",
-    "lint": "node_modules/jshint/bin/jshint lib/*"
+    "test": "mocha test/models/ -t 20000",
+    "lint": "jshint lib/*"
   },
   "author": {
     "name": "Chris Helm"


### PR DESCRIPTION
I learned recently that you don't need to prefix bin paths to installed modules with `node_modules/**/**`.

`lint` script now just uses gulp, so you can run `npm run lint` and it will delegate to gulp. This also circumvents needing to install gulp globally.

Added a badge to show latest version published to npm. Also using flat badge style from http://shields.io for added futurism (looks like this: https://github.com/ngoldman/koop/tree/tweaks#koop).

Ignoring complexity output for git. @JerrySievert I'm noticing the HTML reporter doesn't seem to be generating anything right now so it's not super useful.