### PR TITLE
forcing Lambert_Conformal_Conic_1SP on lambert proj strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.3] - 2015-04-03
+### Changed
+* Forcing export shapefiles with Lambert_Conformal_Conic proj strings to use Lambert_Conformal_Conic_1SP. For more info see: http://trac.osgeo.org/gdal/ticket/2072
+
 ## [2.0.2] - 2015-04-02
 ### Changed
 * Small data exports in worker mode now use the regular exportToFormat workflow in Exporter.js  
@@ -166,6 +170,7 @@ Koop is now just a node module that exposes an express middleware app with hooks
   - koop-server is no more; all central code is in the koop project
   - to use Koop you must use it as middleware in an app that boots up an http server
 
+[2.0.3]: https://github.com/Esri/koop/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Esri/koop/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Esri/koop/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Esri/koop/compare/v1.1.2...v2.0.0

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -411,12 +411,12 @@ function getOgrParams( format, inFile, outFile, geojson, options ){
     }
 
     // make sure field names are not truncated multiple times
-    cmd.push('-append');
     cmd.push('-fieldmap');
     cmd.push('identity');
 
   }
 
+  cmd.push('-append');
   cmd.push('-skipfailures');
   cmd.push('-lco');
   cmd.push('ENCODING=UTF-8');

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -399,8 +399,12 @@ function getOgrParams( format, inFile, outFile, geojson, options ){
   } else if (format === 'zip' || format === 'shp'){
     // only project features for shp when wkid != 4326 or 3857 or 102100
     if ( options.wkid ){
+      var wkt = projCodes.lookup(options.wkid).wkt;
+      // always replace Lambert_Conformal_Conic with Lambert_Conformal_Conic_1SP
+      // open ogr2ogr bug: http://trac.osgeo.org/gdal/ticket/2072
+      wkt = wkt.replace('Lambert_Conformal_Conic', 'Lambert_Conformal_Conic_1SP');
       cmd.push('-t_srs');
-      cmd.push('\''+ projCodes.lookup(options.wkid).wkt +'\'');
+      cmd.push('\''+ wkt +'\'');
     } else if (options.wkt){
       cmd.push('-t_srs');
       cmd.push('\''+ options.wkt +'\'');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koop",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A node module/express middleware for converting GeoJSON to Esri Feature Services.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There is an open issue in GDAL/ogr2ogr around Esri projection strings for Lamert_Conformal_Conic WKT. The fix is to add "_1SP" which sets the standard pararrel param and allows data with this proj to project correctly. 

more info: http://trac.osgeo.org/gdal/ticket/2072