### PR TITLE
Fixes from qa smoketests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.4] - 2015-04-06
+### Changed
+* Sanitizing export file names to protect again quotes in input params to ogr2ogr
+* Better protection against missing proj codes in the esri-proj-code lookup
+
 ## [2.0.3] - 2015-04-03
 ### Changed
 * Forcing export shapefiles with Lambert_Conformal_Conic proj strings to use Lambert_Conformal_Conic_1SP. For more info see: http://trac.osgeo.org/gdal/ticket/2072
@@ -170,6 +175,7 @@ Koop is now just a node module that exposes an express middleware app with hooks
   - koop-server is no more; all central code is in the koop project
   - to use Koop you must use it as middleware in an app that boots up an http server
 
+[2.0.4]: https://github.com/Esri/koop/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Esri/koop/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Esri/koop/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Esri/koop/compare/v2.0.0...v2.0.1

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -377,6 +377,11 @@ function moveFile(inFile, newFile, callback){
 
 
 function getOgrParams( format, inFile, outFile, geojson, options ){
+
+  // escape quotes in file names
+  inFile = inFile.replace(/"/g, '\"');  
+  outFile = outFile.replace(/"/g, '\"');  
+
   var cmd = [
     'ogr2ogr',
     '--config',
@@ -398,12 +403,17 @@ function getOgrParams( format, inFile, outFile, geojson, options ){
   } else if (format === 'zip' || format === 'shp'){
     // only project features for shp when wkid != 4326 or 3857 or 102100
     if ( options.wkid ){
-      var wkt = projCodes.lookup(options.wkid).wkt;
-      // always replace Lambert_Conformal_Conic with Lambert_Conformal_Conic_1SP
-      // open ogr2ogr bug: http://trac.osgeo.org/gdal/ticket/2072
-      wkt = wkt.replace('Lambert_Conformal_Conic', 'Lambert_Conformal_Conic_1SP');
-      cmd.push('-t_srs');
-      cmd.push('\''+ wkt +'\'');
+      var proj = projCodes.lookup(options.wkid);
+      if (proj && proj.wkt){
+        // always replace Lambert_Conformal_Conic with Lambert_Conformal_Conic_1SP
+        // open ogr2ogr bug: http://trac.osgeo.org/gdal/ticket/2072
+        var wkt = proj.wkt;
+        wkt = wkt.replace('Lambert_Conformal_Conic', 'Lambert_Conformal_Conic_1SP');
+        cmd.push('-t_srs');
+        cmd.push('\''+ wkt +'\'');
+      } else {
+        console.log('No proj info found for WKID', options.wkid, outFile);
+      }
     } else if (options.wkt){
       cmd.push('-t_srs');
       cmd.push('\''+ options.wkt +'\'');

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -288,7 +288,6 @@ function callOgr(params, geojson, options, callback){
 
   } else {
     var ogrParams = getOgrParams( format, inFile, outFile, geojson, options );
-    
     exec( ogrParams, function (err) {
         if (err) {
           callback( err.message + ' ' + ogrParams, null );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koop",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A node module/express middleware for converting GeoJSON to Esri Feature Services.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## v2.0.4
### Changed
* Sanitizing export file names to protect again quotes in input params to ogr2ogr
* Better protection against missing proj codes in the esri-proj-code lookup
