### PR TITLE
Export worker fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.1.0] - 2015-04-09
 ### Added 
 * a new route `/export-workers` to inspect the current backlog of export workers if configured to run in worker mode
+* added an idFilter to exports to improve query efficiency over limit/offsets
 
 ### Changed
 * Wrapping export worker in node.js domains to protect against stuck worker jobs. Running inside a domain allows the workers to trap every/any uncaught error and return the job as failed.
 * Adding the moveLargeShapefile method in order to support correct shapefile part naming differences between large data and small data exports. 
- 
+* Using Lambert_Conformal_Conic_2SP instead of 1SP to correct projection errors using 1SP.  
+
 
 ## [2.0.4] - 2015-04-06
 ### Changed

--- a/lib/ExportWorker.js
+++ b/lib/ExportWorker.js
@@ -177,12 +177,12 @@ function createFiles(job, done){
     completed = 0;
 
   var workerQ = async.queue(function(task, cb){
+    var idFilter = ' id >= '+ task.offset + ' AND id < ' + (parseInt(task.offset) + parseInt(task.options.limit));
     var opts = {
       layer: task.options.layer,
-      limit: task.options.limit,
       where: task.options.where,
+      idFilter: idFilter,
       geometry: task.options.geometry,
-      offset: task.offset,
       bypassProcessing: true
     };
   

--- a/lib/ExportWorker.js
+++ b/lib/ExportWorker.js
@@ -69,6 +69,7 @@ jobs.process('exports', 2, function(job, done){
         
         // if we can handle the data in one page 
         if (count < job.data.options.limit) {
+              job.data.options.bypassProcessing = true;
               koop.Cache.db.select(job.data.dbkey, job.data.options, function(err, geojson){
                 delete geojson[0].info;
                 koop.Exporter.exportToFormat( 

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -135,19 +135,20 @@ exports.exportLarge = function( koop, format, id, key, type, options, finish, do
         // return immediately with state: processing
         done(null, info);
 
-        // do all the work inside the worker
-        var task = {};
-        task.options = options;
-        task.options.key = key;
-        task.options.dir = dir;
-        task.dbkey = dbkey;
-        task.table = table;
-        task.format = format;
-        task.finish = finish;
-        task.ogrFormat = ogrFormats[format];
-        task.files = paths;
-        task.pages = [];
+        options.key = key;
+        options.dir = dir;
 
+        // do all the work inside the worker
+        var task = {
+          options: options,
+          dbkey: dbkey,
+          table: table,
+          format: format,
+          finish: finish,
+          ogrFormat: ogrFormats[format],
+          files: paths,
+          pages: []
+        };
         
         if ( !locked ){
           var job = koop.Exporter.export_q.create( 'exports', task ).save( function( err ){
@@ -156,6 +157,8 @@ exports.exportLarge = function( koop, format, id, key, type, options, finish, do
 
           job.on('progress', function(progress){
             
+            // the question is do we need to get the info from the db here? 
+            // TODO explore this in qa and its impact of DB load
             koop.Cache.getInfo( table, function( err, info ){
               info.status = 'processing';
               if (info.generating) {

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -435,7 +435,8 @@ function getOgrParams( format, inFile, outFile, geojson, options ){
         // always replace Lambert_Conformal_Conic with Lambert_Conformal_Conic_1SP
         // open ogr2ogr bug: http://trac.osgeo.org/gdal/ticket/2072
         var wkt = proj.wkt;
-        wkt = wkt.replace('Lambert_Conformal_Conic', 'Lambert_Conformal_Conic_1SP');
+        wkt = wkt.replace('Lambert_Conformal_Conic', 'Lambert_Conformal_Conic_2SP');
+        console.log(wkt);
         cmd.push('-t_srs');
         cmd.push('\''+ wkt +'\'');
       } else {

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -95,12 +95,15 @@ exports.exportLarge = function( koop, format, id, key, type, options, finish, do
   };
 
   var q = async.queue(function (task, cb) {
+    // instead of passing a limit and offset 
+    // we use a WHERE clause 
+    var idFilter = ' id >= '+ options.offset + ' AND id < ' + options.offset + options.limit;
+    var idFilter = ' id >= '+ task.offset + ' AND id < ' + (parseInt(task.offset) + parseInt(task.options.limit));
     var opts = {
+      ifFilter: idFilter,
       layer: options.layer,
-      limit: options.limit,
       where: options.where,
       geometry: options.geometry,
-      offset: task.offset,
       bypassProcessing: true
     };
     koop.Cache.db.select(dbkey, opts, function(err, data){
@@ -436,7 +439,6 @@ function getOgrParams( format, inFile, outFile, geojson, options ){
         // open ogr2ogr bug: http://trac.osgeo.org/gdal/ticket/2072
         var wkt = proj.wkt;
         wkt = wkt.replace('Lambert_Conformal_Conic', 'Lambert_Conformal_Conic_2SP');
-        console.log(wkt);
         cmd.push('-t_srs');
         cmd.push('\''+ wkt +'\'');
       } else {


### PR DESCRIPTION
More crucial fixes for 2.1.0 before I publish the release. The reason that this is v2.1.0 is due to the change in the way offset/limits pagination on large data exports is handled. Koop exports now use a WHERE clause based paging structure that is free of the poor performance you get from using high OFFSET values. 