### PR TITLE
ordered fields if header info is saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.9] - 2015-05-21
+### Changed 
+* Sending any stored header/field lists to the featureserver code to support ordered fields coming from CSVs data.
+* More logic around not exporting X/Y values when data attributes contain an x and y prop. 
+
 ## [2.1.8] - 2015-05-19
 ### Removed 
 * A misleading error log on start up that was left in the index.js
@@ -239,6 +244,7 @@ Koop is now just a node module that exposes an express middleware app with hooks
   - koop-server is no more; all central code is in the koop project
   - to use Koop you must use it as middleware in an app that boots up an http server
 
+[2.1.9]: https://github.com/Esri/koop/compare/v2.1.8...v2.1.9
 [2.1.8]: https://github.com/Esri/koop/compare/v2.1.7...v2.1.8
 [2.1.7]: https://github.com/Esri/koop/compare/v2.1.6...v2.1.7
 [2.1.6]: https://github.com/Esri/koop/compare/v2.1.5...v2.1.6

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -428,7 +428,7 @@ function getOgrParams( format, inFile, outFile, geojson, options ){
   ];
 
   if (format === 'csv') {
-    if ( geojson && geojson.features && geojson.features.length && geojson.features[0].geometry && geojson.features[0].geometry.type == 'Point' && (!geojson.features[0].properties['x'] && !geojson.features[0].properties['y'])){
+    if ( geojson && geojson.features && geojson.features.length && geojson.features[0].geometry && geojson.features[0].geometry.type == 'Point' && ((!geojson.features[0].properties['x'] && !geojson.features[0].properties['y']) || (!geojson.features[0].properties['X'] && !geojson.features[0].properties['Y']))){
       cmd.push('-lco');
       cmd.push('WRITE_BOM=YES');
       cmd.push('-lco');

--- a/lib/FeatureServices.js
+++ b/lib/FeatureServices.js
@@ -34,10 +34,18 @@ module.exports = {
     return Math.round( v ) === v;
   },
 
-  fields: function( props, idField ){
+  fields: function( props, idField, list ){
     var self = this;
-    var fields = [], type;
-    Object.keys( props ).forEach(function( key ){
+    var fields = [], 
+      type, 
+      fieldList;
+
+    if (list) {
+      fieldList = list;
+    } else {
+      fieldList = Object.keys( props );
+    }
+    fieldList.forEach(function( key ){
       if ( key === 'OBJECTID' && !idField){
         idField = key;
       }
@@ -66,6 +74,7 @@ module.exports = {
         alias: idField
       });
     }
+    
     return {
       oidField: idField, 
       fields: fields
@@ -77,7 +86,7 @@ module.exports = {
     var fieldObj;
     var template = JSON.parse(fs.readFileSync(__dirname + tmpl).toString());
     if ( !data.length && data.features && data.features.length ){
-      fieldObj = this.fields( data.features[0].properties, params.idField ); 
+      fieldObj = this.fields( data.features[0].properties, params.idField, data.info.fields ); 
       template.fields = fieldObj.fields;
       if (template.objectIdFieldName) {
         template.objectIdFieldName = fieldObj.oidField;
@@ -85,7 +94,7 @@ module.exports = {
         template.objectIdField = fieldObj.oidField;
       }
     } else if (data[0] && data[0].features[0] && data[0].features[0].length ) {
-      fieldObj = this.fields( data[0].features[0].properties, params.idField );
+      fieldObj = this.fields( data[0].features[0].properties, params.idField, data[0].info.fields);
       template.fields = fieldObj.fields;
       if (template.objectIdFieldName) {
         template.objectIdFieldName = fieldObj.oidField;

--- a/lib/FeatureServices.js
+++ b/lib/FeatureServices.js
@@ -86,7 +86,7 @@ module.exports = {
     var fieldObj;
     var template = JSON.parse(fs.readFileSync(__dirname + tmpl).toString());
     if ( !data.length && data.features && data.features.length ){
-      fieldObj = this.fields( data.features[0].properties, params.idField, data.info.fields ); 
+      fieldObj = this.fields( data.features[0].properties, params.idField, (data.info) ? data.info.fields : null ); 
       template.fields = fieldObj.fields;
       if (template.objectIdFieldName) {
         template.objectIdFieldName = fieldObj.oidField;
@@ -94,7 +94,7 @@ module.exports = {
         template.objectIdField = fieldObj.oidField;
       }
     } else if (data[0] && data[0].features[0] && data[0].features[0].length ) {
-      fieldObj = this.fields( data[0].features[0].properties, params.idField, data[0].info.fields);
+      fieldObj = this.fields( data[0].features[0].properties, params.idField, (data[0].info) ? data[0].info.fields : null);
       template.fields = fieldObj.fields;
       if (template.objectIdFieldName) {
         template.objectIdFieldName = fieldObj.oidField;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koop",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "A node module/express middleware for converting GeoJSON to Esri Feature Services.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If a dataset has saved an array of fields the Koop featureservice code will use that for its list of fields. This preserves the original original field order from CSV data. 