### PR TITLE
fixing the zero config crashing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Added jsdocs to methods in `lib/Cache.js` 
 ### Changed
 * Providers can now optionally pass in an extent that FeatureServices will use instead of looping over features 
+* If no config is passed in one will get created as an empty object. This protects koop from crashing with no config (#186).
 
 ## [2.1.12] - 2015-06-12
 ### Changed 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ module.exports = function( config ) {
 
   // keep track of the registered services
   app.services = {};
-
+  
+  // if config is undefined, create it
+  config = config || {};
   koop.config = config;
 
   // handle POST requests


### PR DESCRIPTION
Creates an empty config object if none is passed. The files that were crashing koop before always check for params so all we needed to do was have a short circuit for the config object in the index.js 

closes #186 