### PR TITLE
Wkt wkid out sr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added 
 * A centralized spatial reference parsing class that is exposed in `lib/BaseModel.js` and used in `lib/Exporter.js` 
+* Adds support for options.wkid, options.wkt, or options.outSR in lib/Exporter.js
 
 ## [2.3.0] - 2015-07-02
 ### Added

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -471,20 +471,25 @@ function getOgrParams( format, inFile, outFile, geojson, options ){
     }
   } else if (format === 'zip' || format === 'shp'){
     // only project features for shp when wkid != 4326 or 3857 or 102100
+    var wkid, wkt, sr;
     if ( options.outSR ){
-      var sr = spatialReference.parse(options.outSR);
-      if (sr.wkid) {
-        var proj = projCodes.lookup(sr.wkid);
-        if (proj && proj.wkt) {
-          cmd.push('-t_srs');
-          cmd.push('\''+ fixWkt(proj.wkt, sr.wkid) +'\'');
-        } else {
-          console.log('No proj info found for WKID', sr.wkid, outFile);
-        }
-      } else if (sr.wkt) {
+      sr = spatialReference.parse(options.outSR);
+    } 
+
+    wkid = sr.wkid || options.wkid;
+    wkt = sr.wkt || options.wkt;
+
+    if (wkid) {
+      var proj = projCodes.lookup(sr.wkid);
+      if (proj && proj.wkt) {
         cmd.push('-t_srs');
-        cmd.push('\''+ fixWkt(sr.wkt) +'\'');
+        cmd.push('\''+ fixWkt(proj.wkt, sr.wkid) +'\'');
+      } else {
+        console.log('No proj info found for WKID', sr.wkid, outFile);
       }
+    } else if (wkt) {
+      cmd.push('-t_srs');
+      cmd.push('\''+ fixWkt(sr.wkt) +'\'');
     }
 
     // make sure field names are not truncated multiple times
@@ -500,6 +505,7 @@ function getOgrParams( format, inFile, outFile, geojson, options ){
   cmd.push('ENCODING=UTF-8');
   return cmd.join(' '); 
 };
+
 
 exports.createPaths = createPaths;
 exports.callOgr = callOgr;


### PR DESCRIPTION
This brings back support for wkid, and wkt in addition to supporting outSR. If any of those are present koop will attempt to reproject SHP exports. This mean reprojection is still "on-demand" and providers can choose when a dataset gets re-projected. 