### PR TITLE
[DNM] standardize & refactor

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -1,53 +1,62 @@
-var winston = require('winston');
+var winston = require('winston')
 
-function Logger( config ){
-
-  var transports;
-  if ( config.logfile ){
-
-    // we need a dir to do log rotation so we get the dir from the file
-    var logpath = config.logfile.split('/');
-    logpath.splice(-1,1);
-    logpath = logpath.join('/');
-
-    // define a custom log formatter
-    var formatter = function(options) {
-      return [
-        new Date().toISOString(),
-        options.level, 
-        (undefined !== options.message ? options.message : ''),
-        (options.meta && Object.keys(options.meta).length ? JSON.stringify(options.meta) : '' )
-      ].join(' ');
-    };
-
-    transports = [
-      new (winston.transports.DailyRotateFile)({
-        filename: config.logfile,
-        name: 'log.all',
-        dirname: logpath,
-        datePattern: '.yyyy-MM-dd',
-        colorize: true,
-        json: false,        
-        level: 'debug',
-        formatter: formatter
-      }),
-      new (winston.transports.DailyRotateFile)({
-        filename: config.logfile + '.error',
-        name: 'log.error',
-        dirname: logpath,
-        datePattern: '.yyyy-MM-dd',
-        colorize: true,
-        json: false,        
-        level: 'error',
-        formatter: formatter
-      }),
-    ];
-  } else {
-    // no logfile defined, log to console only
-    transports = [ new (winston.transports.Console)({ level: 'debug' }) ];
+/**
+ * returns a new logger instance
+ * @param {Object} config
+ */
+function Logger (config) {
+  // return early: if no logfile defined, log to console only
+  if (!config.logfile) {
+    var debugConsole = new winston.transports.Console({ level: 'debug' })
+    return new winston.Logger({ transports: [debugConsole] })
   }
-  return new (winston.Logger)({ transports: transports });
 
+  // we need a dir to do log rotation so we get the dir from the file
+  var logpath = config.logfile.split('/').splice(-1, 1).join('/')
+  var logAll = new winston.transports.DailyRotateFile({
+    filename: config.logfile,
+    name: 'log.all',
+    dirname: logpath,
+    datePattern: '.yyyy-MM-dd',
+    colorize: true,
+    json: false,
+    level: 'debug',
+    formatter: formatter
+  })
+  var logError = new winston.transports.DailyRotateFile({
+    filename: config.logfile + '.error',
+    name: 'log.error',
+    dirname: logpath,
+    datePattern: '.yyyy-MM-dd',
+    colorize: true,
+    json: false,
+    level: 'error',
+    formatter: formatter
+  })
+
+  return new winston.Logger({ transports: [logAll, logError] })
 }
 
-module.exports = Logger;
+/**
+ * format level, message, and meta into a new log string
+ * @param  {Object} options should contain level, message, meta
+ * @return {String}         formatted log string
+ */
+function formatter (options) {
+  var line = [
+    new Date().toISOString(),
+    options.level
+  ]
+
+  if (options.message !== undefined) {
+    line.push(options.message)
+  }
+
+  if (options.meta && Object.keys(options.meta).length) {
+    line.push(JSON.stringify(options.meta))
+  }
+
+  return line.join(' ')
+}
+
+module.exports = Logger


### PR DESCRIPTION
:no_entry_sign: **Do Not Merge**

Starting the process of refactoring `lib` with an eye for pulling files out altogether into modules. I think `Logger` still belongs in `koop`. Standardized it and made it a little easier to read.

:construction: **work in progress** :construction: 